### PR TITLE
Add missing networks to Yearn

### DIFF
--- a/data.json
+++ b/data.json
@@ -4075,7 +4075,7 @@
     "packages": "",
     "modules_guards": "",
     "safe_apps_smart": "No",
-    "networks": "Ethereum",
+    "networks": "Arbitrum, Base, Ethereum, Optimism, Polygon",
     "interface_can_you_create_a_safe": "",
     "interface_can_you_import_an_existing_safe": ""
   },


### PR DESCRIPTION
supported networks are Arbitrum, Base, Ethereum, Optimism, Polygon