### PR TITLE
CSV Airdrop: Add Sepolia as Supported Network

### DIFF
--- a/data.json
+++ b/data.json
@@ -831,7 +831,7 @@
     "packages": "safe-apps-provider",
     "modules_guards": "",
     "safe_apps_smart": "Batch transactions",
-    "networks": "Arbitrum, Aurora, Avalanche, BNB Chain, Ethereum, Gnosis Chain, Optimism, Polygon",
+    "networks": "Arbitrum, Aurora, Avalanche, BNB Chain, Ethereum, Gnosis Chain, Optimism, Polygon, Sepolia",
     "interface_can_you_create_a_safe": "",
     "interface_can_you_import_an_existing_safe": ""
   },


### PR DESCRIPTION
Hey, I was preparing for a workshop and noticed that this app is not listed in Sepolia. 
Could we please get this in by Thursday -- It would really help distribute gas for a workshop!

cc @schmanu 