### PR TITLE
feat: fetch data from Attio

### DIFF
--- a/.github/workflows/update-ecosystem.yml
+++ b/.github/workflows/update-ecosystem.yml
@@ -1,0 +1,58 @@
+name: Update Ecosystem
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-ecosystem:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+
+      - name: Create new branch
+        run: |
+          # Get current date for branch name
+          branch_name="ecosystem-update-$(date +'%Y-%m-%d')"
+          git checkout -b $branch_name
+          echo "BRANCH_NAME=$branch_name" >> $GITHUB_ENV
+
+      - name: Update ecosystem
+        env:
+          ATTIO_API_TOKEN: ${{ secrets.ATTIO_API_TOKEN }}
+        run: node scripts/attio/updateEcosystem.js
+
+      - name: Commit changes
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add data.json logos/
+          git commit -m "chore: update ecosystem data [skip ci]" || echo "No changes to commit"
+
+      - name: Push changes
+        run: |
+          git push origin ${{ env.BRANCH_NAME }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "chore: update ecosystem data"
+          body: |
+            🤖 This PR was automatically generated to update the ecosystem database.
+
+            ## Changes
+            - Updated `data.json` with latest ecosystem data
+            - Updated company logos in `logos/` directory
+
+            Please review the changes and merge if everything looks correct.
+          branch: ${{ env.BRANCH_NAME }}
+          base: main
+          labels: |
+            automated
+            ecosystem-update

--- a/scripts/attio/fetchActiveCompanies.js
+++ b/scripts/attio/fetchActiveCompanies.js
@@ -144,10 +144,6 @@ function mapCompanyData(activeCompaniesData) {
     };
   });
 
-  console.log(
-    "First 3 company names",
-    mappedData.slice(0, 3).map((company) => company.project)
-  );
   return mappedData;
 }
 

--- a/scripts/attio/fetchActiveCompanies.js
+++ b/scripts/attio/fetchActiveCompanies.js
@@ -1,0 +1,189 @@
+// Fetch active entries from the Ecosystem list
+async function fetchActiveEntries() {
+  console.log("Fetching active entries from the Ecosystem list");
+  const response = await fetch(
+    "https://api.attio.com/v2/lists/ecosystem/entries/query",
+    {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        authorization: `Bearer ${process.env.ATTIO_API_TOKEN}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        filter: {
+          status_3: "Active",
+        },
+      }),
+    }
+  );
+
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch ecosystem entries: ${response.status} ${response.statusText}`
+    );
+  }
+
+  const activeEntries = await response.json();
+
+  console.log(
+    `Fetched ${activeEntries.data.length} entries from ecosystem list\n`
+  );
+
+  return activeEntries.data;
+}
+
+// Extract company IDs and ecosystem data from entries
+function extractEcosystemFields(entriesData) {
+  return entriesData.map((item) => ({
+    parent_record_id: item.parent_record_id,
+    modules_guards:
+      item.entry_values?.modules_guards?.map((mod) => mod.value).join(", ") ||
+      "",
+    safe_apps_smart: item.entry_values?.sa_application?.[0]?.value || "",
+  }));
+}
+
+// Fetch company details from the companies API
+async function fetchCompanyDetails(ecosystemFields) {
+  const allCompaniesData = [];
+
+  // Process IDs in chunks of 100 due to API limit
+  for (let i = 0; i < ecosystemFields.length; i += 100) {
+    const chunk = ecosystemFields.slice(i, i + 100);
+    console.log(`Fetching companies ${i + 1} to ${i + chunk.length}`);
+
+    const response = await fetch(
+      "https://api.attio.com/v2/objects/companies/records/query",
+      {
+        method: "POST",
+        headers: {
+          accept: "application/json",
+          authorization: `Bearer ${process.env.ATTIO_API_TOKEN}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          filter: {
+            record_id: {
+              $in: chunk.map((entry) => entry.parent_record_id),
+            },
+          },
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to fetch companies (chunk ${i + 1} to ${i + chunk.length}): ${
+          response.status
+        } ${response.statusText}`
+      );
+    }
+
+    const companiesData = await response.json();
+
+    // Merge ecosystem data with company data
+    const mergedData = companiesData.data.map((company) => {
+      const ecosystemEntry = chunk.find(
+        (entry) => entry.parent_record_id === company.id.record_id
+      );
+
+      const companyName = company.values?.name?.[0]?.value || "";
+      return {
+        ...company,
+        sanitizedName: sanitizeFilename(companyName),
+        modules_guards: ecosystemEntry.modules_guards,
+        safe_apps_smart: ecosystemEntry.safe_apps_smart,
+      };
+    });
+
+    allCompaniesData.push(...mergedData);
+  }
+
+  console.log(`Fetched details for ${allCompaniesData.length} companies`);
+
+  return allCompaniesData;
+}
+
+// Clean filename for filesystem (same as in fetchLogos.js)
+function sanitizeFilename(filename) {
+  return filename.toLowerCase().replace(/[^a-z0-9]/g, "-");
+}
+
+// Map company data to required format
+function mapCompanyData(activeCompaniesData) {
+  const mappedData = activeCompaniesData.map((company) => {
+    const values = company.values;
+
+    const companyName = values?.name?.[0]?.value || "";
+    const sanitizedName = sanitizeFilename(companyName);
+
+    return {
+      project: companyName,
+      description: values?.description?.[0]?.value || "",
+      project_scope: values?.project_scope?.[0]?.option?.title || "",
+      primary_category: values?.primary_category?.[0]?.option?.title || "",
+      secondary_categories:
+        values?.secondary_categories
+          ?.map((cat) => cat.option?.title)
+          .join(", ") || "",
+      logo_url: values?.logo_url?.[0]?.value || "",
+      logo_path: companyName ? `/logos/${sanitizedName}` : "",
+      value_prop: values?.value_prop?.[0]?.value || "",
+      project_website: values?.domains?.[0]?.domain || "",
+      github_dev_docs: values?.github_5?.[0]?.value || "",
+      twitter: values?.twitter?.[0]?.value || "",
+      primary_integration:
+        values?.primary_integration?.[0]?.option?.title || "",
+      packages:
+        values?.packages?.map((pkg) => pkg.option?.title).join(", ") || "",
+      modules_guards: company.modules_guards || "",
+      safe_apps_smart: company.safe_apps_smart || "",
+      networks:
+        values?.networks?.map((net) => net.option?.title).join(", ") || "",
+    };
+  });
+
+  console.log(
+    "First 3 company names",
+    mappedData.slice(0, 3).map((company) => company.project)
+  );
+  return mappedData;
+}
+
+// Save results to file and log summary
+function saveAndLogResults(mappedCompanies) {
+  require("fs").writeFileSync(
+    "data.json",
+    JSON.stringify(mappedCompanies, null, 2)
+  );
+
+  console.log("\nData has been saved to 'data.json'");
+  console.log(`Total companies processed: ${mappedCompanies.length}`);
+}
+
+// Main function that orchestrates the process
+async function getActiveCompanies() {
+  try {
+    const activeEntries = await fetchActiveEntries();
+    const ecosystemFields = extractEcosystemFields(activeEntries);
+    const activeCompaniesData = await fetchCompanyDetails(ecosystemFields);
+    const mappedCompanies = mapCompanyData(activeCompaniesData);
+
+    saveAndLogResults(mappedCompanies);
+    return activeCompaniesData; // Return the raw data for logo processing
+  } catch (error) {
+    console.error("Error:", error.message);
+    if (error.response) {
+      console.error("API Response:", error.response.data);
+    }
+    process.exit(1);
+  }
+}
+
+// Allow both direct execution and importing
+if (require.main === module) {
+  getActiveCompanies();
+}
+
+module.exports = { getActiveCompanies };

--- a/scripts/attio/fetchActiveCompanies.js
+++ b/scripts/attio/fetchActiveCompanies.js
@@ -177,7 +177,7 @@ async function getActiveCompanies() {
   }
 }
 
-// Allow both direct execution and importing
+// Only allow importing
 if (require.main === module) {
   getActiveCompanies();
 }

--- a/scripts/attio/fetchLogos.js
+++ b/scripts/attio/fetchLogos.js
@@ -1,0 +1,77 @@
+const fs = require("fs");
+const path = require("path");
+
+// Create logos directory if it doesn't exist
+const LOGOS_DIR = "./logos";
+if (!fs.existsSync(LOGOS_DIR)) {
+  fs.mkdirSync(LOGOS_DIR);
+}
+
+// MIME type to file extension mapping
+const MIME_TO_EXT = {
+  "image/jpeg": ".jpg",
+  "image/jpg": ".jpg",
+  "image/png": ".png",
+  "image/gif": ".gif",
+  "image/webp": ".webp",
+  "image/svg+xml": ".svg",
+};
+
+// Download image from URL
+async function downloadImage(url, filepath) {
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Failed to download: ${response.status}`);
+  }
+
+  const contentType = response.headers.get("content-type");
+  const extension = MIME_TO_EXT[contentType] || ".png";
+
+  // Update filepath with correct extension if needed
+  const finalFilepath = filepath.endsWith(extension)
+    ? filepath
+    : filepath.replace(/\.[^/.]+$/, "") + extension;
+
+  const buffer = await response.arrayBuffer();
+  fs.writeFileSync(finalFilepath, Buffer.from(buffer));
+  return finalFilepath;
+}
+
+async function fetchAndSaveLogos(companiesData) {
+  try {
+    console.log(`Processing ${companiesData.length} companies for logos...`);
+
+    for (const company of companiesData) {
+      const companyName = company.values?.name?.[0]?.value;
+      const logoUrl = company.values?.logo_url?.[0]?.value;
+
+      if (companyName && logoUrl) {
+        const filepath = path.join(LOGOS_DIR, company.sanitizedName);
+
+        try {
+          await downloadImage(logoUrl, filepath);
+        } catch (error) {
+          console.error(
+            `× Failed to download logo for ${companyName}:`,
+            error.message
+          );
+        }
+      }
+    }
+
+    console.log("\nLogo download process completed!");
+  } catch (error) {
+    console.error("Error processing logos:", error.message);
+    process.exit(1);
+  }
+}
+
+// Allow both direct execution and importing
+if (require.main === module) {
+  console.error(
+    "This script should be called with company data from updateEcosystem.js"
+  );
+  process.exit(1);
+}
+
+module.exports = { fetchAndSaveLogos };

--- a/scripts/attio/updateEcosystem.js
+++ b/scripts/attio/updateEcosystem.js
@@ -1,0 +1,27 @@
+const { getActiveCompanies } = require("./fetchActiveCompanies");
+const { fetchAndSaveLogos } = require("./fetchLogos");
+
+// Check for required environment variable
+if (!process.env.ATTIO_API_TOKEN) {
+  console.error("Error: ATTIO_API_TOKEN environment variable is required");
+  process.exit(1);
+}
+
+async function updateEcosystem() {
+  try {
+    // First fetch companies data
+    console.log("Fetching companies data...");
+    const companiesData = await getActiveCompanies();
+
+    // Then fetch and save logos
+    console.log("\nFetching company logos...");
+    await fetchAndSaveLogos(companiesData);
+
+    console.log("\n✓ Ecosystem update completed successfully!");
+  } catch (error) {
+    console.error("Error updating ecosystem:", error.message);
+    process.exit(1);
+  }
+}
+
+updateEcosystem();


### PR DESCRIPTION
## What it solves

- Create a workflow to fetch the Ecosystem data from Attio through the API.
- The workflow creates a PR where the changes to `data.json` and the `/logos` folder can be seen.

## How this PR solves it
I've opted to keep the hosting of the projects in the same format (`data.json` + logos folder) so we can rely on our service availability and live changes on Attio's entries do not break the projects list on https://safe.global/ecosystem.